### PR TITLE
node-dev missing as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "gulp-util": "^3.0.7",
     "history": "^1.13.0",
     "npm-run-all": "^1.2.12",
+    "node-dev": "^3.1.0",
     "react": "^0.14.1",
     "react-dom": "^0.14.1",
     "react-router": "^1.0.0",


### PR DESCRIPTION
Went to run the sample and it error'd out.  Turns out I didn't have node-dev installed globally, might be a good idea to add it as a devDependency.

Not sure how you'd want to treat this within the other branches.
